### PR TITLE
Fix bug 379 for OpenAudacity (Upstream)

### DIFF
--- a/lib-src/libnyquist/nyquist/xlisp/xlftab.c
+++ b/lib-src/libnyquist/nyquist/xlisp/xlftab.c
@@ -277,7 +277,9 @@ FUNDEF init_funtab[] = {
 /* end of functions specific to xldmem.c */
 
 {	"TYPE-OF",			S, xtype		}, /* 194 */
-{	"EXIT",				S, xexit		}, /* 195 */
+/* See Audacity bug 379 */
+/* {	"EXIT",				S, xexit		}, */
+{	NULL,				S, xexit		}, /* 195 */
 #ifdef PEEK_AND_POKE
 {	"PEEK",				S, xpeek		}, /* 196 */
 {	"POKE",				S, xpoke		}, /* 197 */


### PR DESCRIPTION
EXIT should not be defined in Audacity's implementation of Nyquist

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->
- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing](https://github.com/moralesresearch/OpenAudacity/blob/master/CONTRIBUTING.md))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
